### PR TITLE
Fix unusable logging

### DIFF
--- a/nakama/util/log.lua
+++ b/nakama/util/log.lua
@@ -20,7 +20,7 @@ function M.custom(fn)
 	M.log = fn
 end
 
-M.log = M.silent()
+M.silent()
 
 setmetatable(M, {
 	__call = function(t, ...)


### PR DESCRIPTION
Tried using this client to switch from NoobHub to Nakama (thanks @britzl for both :+1: ), ended up with this:

```
ERROR:SCRIPT: /nakama/util/log.lua:27: attempt to call field 'log' (a nil value)
stack traceback:
	/nakama/util/log.lua:27: in function 'log'
	/nakama/nakama.lua:1094: in function 'create_client'
```

Went through the code, got the point of how it was meant to work and what's wrong. 
I suppose methods of `nakama.util.log` are supposed to switch logging method so when you need to suppress all the messages you use `log.silent()` and then `log.print()` or any custom thing when you need your logs back.

However the initial `M.log = M.silent()` is faulty since it returns `nil` which means `M.log` is now `nil`, and since the whole module is callable, it becomes `nil` and breaks the whole client from the very beginning.

I figured couple of ways of fixing it but the easiest (and hopefully the one that doesn't ruin the intended approach) is the one in this PR.

Appreciate your work!