### PR TITLE
Fix response with an empty JSON object in `status_update` message

### DIFF
--- a/nakama/engine/defold.lua
+++ b/nakama/engine/defold.lua
@@ -150,8 +150,8 @@ function M.socket_send(socket, message, callback)
 	socket.requests[message.cid] = callback
 
 	local data = json.encode(message)
-	-- Fix encoding of match_create_message to send {} instead of []
-	if message.match_create ~= nil then
+	-- Fix encoding of match_create and status_update messages to send {} instead of []
+	if message.match_create ~= nil or message.status_update ~= nil then
 		data = string.gsub(data, "%[%]", "{}")
 	end
 


### PR DESCRIPTION
Just a quick addition to replacing JSON'ed `[]` with `{}` not only in `match_create` messages, but in `status_update` as well