### PR TITLE
Use logger for functions mapping debug messages

### DIFF
--- a/codegen/rest.go
+++ b/codegen/rest.go
@@ -107,7 +107,7 @@ function M.create_client(config)
 	local ignored_fns = { create_client = true, sync = true }
 	for name,fn in pairs(M) do
 		if not ignored_fns[name] and type(fn) == "function" then
-			print("setting", name)
+			log("setting " .. name)
 			client[name] = function(...) return fn(client, ...) end
 		end
 	end

--- a/nakama/nakama.lua
+++ b/nakama/nakama.lua
@@ -97,7 +97,7 @@ function M.create_client(config)
 	local ignored_fns = { create_client = true, sync = true }
 	for name,fn in pairs(M) do
 		if not ignored_fns[name] and type(fn) == "function" then
-			print("setting", name)
+			log("setting " .. name)
 			client[name] = function(...) return fn(client, ...) end
 		end
 	end


### PR DESCRIPTION
A long sheet of prints kept annoying me, decided to finally deal with them. I don't think removing them entirely is a good idea so just switched prints to log calls so it remains useful in troubleshooting.