### PR TITLE
Fixes function body argument name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed issue with wrong argument name for `nakama.rpc_func`
+
 ## [3.2.0] - 2023-12-11
 ### Changed
 - Use native Defold json encode and decode functions

--- a/codegen/rest.go
+++ b/codegen/rest.go
@@ -229,7 +229,7 @@ end
 {{- bodyFunctionArgsDocs $parameter.Schema.Ref }}
 {{- end }}
 {{- if and (eq $parameter.In "body") $parameter.Schema.Type }}
--- @param body ({{ $parameter.Schema.Type }}) {{ $parameter.Description | stripNewlines }}
+-- @param {{ $parameter.Name }} ({{ $parameter.Schema.Type }}) {{ $parameter.Description | stripNewlines }}
 {{- end }}
 {{- if ne $parameter.In "body" }}
 -- @param {{ $varName }} ({{ $parameter.Schema.Type }}) {{ $parameter.Description | stripNewlines }}
@@ -260,7 +260,7 @@ function M.{{ $operation.OperationId | pascalToSnake | removePrefix }}(client
 	{{- bodyFunctionArgsAssert $parameter.Schema.Ref}}
 	{{- end }}
 	{{- if and (eq $parameter.In "body") $parameter.Schema.Type }}
-	assert({{- if $parameter.Required }}body and {{ end }}type(body) == "{{ $parameter.Schema.Type }}", "Argument 'body' must be of type '{{ $parameter.Schema.Type }}'")
+	assert({{- if $parameter.Required }}{{ $parameter.Name }} and {{ end }}type({{ $parameter.Name }}) == "{{ $parameter.Schema.Type }}", "Argument '{{ $parameter.Name }}' must be of type '{{ $parameter.Schema.Type }}'")
 	{{- end }}
 
 	{{- end }}
@@ -296,7 +296,7 @@ function M.{{ $operation.OperationId | pascalToSnake | removePrefix }}(client
 		{{- bodyFunctionArgsTable $parameter.Schema.Ref}}	})
 	{{- end }}
 	{{- if $parameter.Schema.Type }}
-	post_data = json.encode(body)
+	post_data = json.encode({{ $parameter.Name }})
 	{{- end }}
 		{{- end }}
 	{{- end }}

--- a/nakama/nakama.lua
+++ b/nakama/nakama.lua
@@ -2498,7 +2498,7 @@ end
 -- Execute a Lua function on the server.
 -- @param client Nakama client.
 -- @param id_str () The identifier of the function.
--- @param body (string) The payload of the function which must be a JSON object.
+-- @param payload (string) The payload of the function which must be a JSON object.
 -- @param http_key_str () The authentication key used when executed as a non-client HTTP request.
 -- @param callback Optional callback function
 -- A coroutine is used and the result is returned if no callback function is provided.
@@ -2508,7 +2508,7 @@ end
 function M.rpc_func(client, id_str, payload, http_key_str, callback, retry_policy, cancellation_token)
 	assert(client, "You must provide a client")
 
-	assert(body and type(body) == "string", "Argument 'body' must be of type 'string'")
+	assert(payload and type(payload) == "string", "Argument 'payload' must be of type 'string'")
 
 	local url_path = "/v2/rpc/{id}"
 	url_path = url_path:gsub("{id}", uri_encode(id_str))
@@ -2517,7 +2517,7 @@ function M.rpc_func(client, id_str, payload, http_key_str, callback, retry_polic
 	query_params["httpKey"] = http_key_str
 
 	local post_data = nil
-	post_data = json.encode(body)
+	post_data = json.encode(payload)
 
 	return http(client, callback, url_path, query_params, "POST", post_data, retry_policy, cancellation_token, function(result)
 		if not result.error and api_rpc then


### PR DESCRIPTION
The generated code was in some cases hardcoded to expect the parameter for the API endpoint to be named `body`. In the case of nakama.rpc_func() the argument was named `payload` instead of `body`. This PR uses the actual parameter name instead of the hardcoded name.

Fixes #72 