### PR TITLE
Fix match and party data message callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed issue with wrong argument name for `nakama.rpc_func`
-- Fixed `socket.party_data_send()` and `socket.match_data_send()` so that they no longer wait for a response from the server, since both of these messages won't trigger a response from the server.
+- Updated several of the socket messages so that they no longer incorrectly wait for a response from the server.
 
 ## [3.2.0] - 2023-12-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.3.0] - 2024-06-14
 ### Fixed
 - Fixed issue with wrong argument name for `nakama.rpc_func`
 - Updated several of the socket messages so that they no longer incorrectly wait for a response from the server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed issue with wrong argument name for `nakama.rpc_func`
+- Fixed `socket.party_data_send()` and `socket.match_data_send()` so that they no longer wait for a response from the server, since both of these messages won't trigger a response from the server.
 
 ## [3.2.0] - 2023-12-11
 ### Changed

--- a/codegen/realtime.py
+++ b/codegen/realtime.py
@@ -35,14 +35,13 @@ local function socket_send(socket, message, callback)
 	if message.match_data_send and message.match_data_send.data then
 		message.match_data_send.data = b64.encode(message.match_data_send.data)
 	end
-
 	if callback then
 		if message.cid then
 			socket.requests[message.cid] = callback
 			socket.engine.socket_send(socket, message)
 		else
 			socket.engine.socket_send(socket, message)
-			callback(true)
+			callback({})
 		end
 	else
 		return async(function(done)
@@ -51,7 +50,7 @@ local function socket_send(socket, message, callback)
 				socket.engine.socket_send(socket, message)
 			else
 				socket.engine.socket_send(socket, message)
-				done(true)
+				done({})
 			end
 		end)
 	end
@@ -279,6 +278,7 @@ def event_to_lua(event_id, api):
 
 
 def messages_to_lua(rtapi):
+	# list of message names that should generate Lua code
 	CHANNEL_MESSAGES = [ "ChannelJoin", "ChannelLeave", "ChannelMessageSend", "ChannelMessageRemove", "ChannelMessageUpdate" ]
 	MATCH_MESSAGES = [ "MatchDataSend", "MatchCreate", "MatchJoin", "MatchLeave" ]
 	MATCHMAKER_MESSAGES = [ "MatchmakerAdd", "MatchmakerRemove" ]
@@ -286,7 +286,14 @@ def messages_to_lua(rtapi):
 	STATUS_MESSAGES = [ "StatusFollow", "StatusUnfollow", "StatusUpdate" ]
 	ALL_MESSAGES = CHANNEL_MESSAGES + MATCH_MESSAGES + MATCHMAKER_MESSAGES + PARTY_MESSAGES + STATUS_MESSAGES
 
-	NO_CALLBACK_MESSAGES = [ "MatchDataSend", "PartyDataSend" ]
+	# list of messages that do not expect a server response
+	CHANNEL_MESSAGES_NOCB = [ "ChannelLeave" ]
+	MATCH_MESSAGES_NOCB = [ "MatchLeave", "MatchDataSend"]
+	MATCHMAKER_MESSAGES_NOCB = [ "MatchmakerRemove" ]
+	PARTY_MESSAGES_NOCB = [ "PartyDataSend", "PartyAccept", "PartyClose", "PartyJoin", "PartyLeave", "PartyPromote", "PartyRemove", "PartyMatchmakerRemove" ]
+	STATUS_MESSAGES_NOCB = [ "StatusUnfollow", "StatusUpdate" ]
+	
+	NO_CALLBACK_MESSAGES = CHANNEL_MESSAGES_NOCB + MATCH_MESSAGES_NOCB + MATCHMAKER_MESSAGES_NOCB + PARTY_MESSAGES_NOCB + STATUS_MESSAGES_NOCB
 
 	ids = []
 	lua = ""

--- a/codegen/realtime.py
+++ b/codegen/realtime.py
@@ -15,6 +15,13 @@ local function on_socket_message(socket, message)
 	if message.match_data then
 		message.match_data.data = b64.decode(message.match_data.data)
 	end
+	if message.cid then
+		local callback = socket.requests[message.cid]
+		if callback then
+			callback(message)
+		end
+		socket.requests[message.cid] = nil
+	end
 	for event_id,_ in pairs(message) do
 		if socket.events[event_id] then
 			socket.events[event_id](message)
@@ -30,10 +37,22 @@ local function socket_send(socket, message, callback)
 	end
 
 	if callback then
-		socket.engine.socket_send(socket, message, callback)
+		if message.cid then
+			socket.requests[message.cid] = callback
+			socket.engine.socket_send(socket, message)
+		else
+			socket.engine.socket_send(socket, message)
+			callback(true)
+		end
 	else
 		return async(function(done)
-			socket.engine.socket_send(socket, message, done)
+			if message.cid then
+				socket.requests[message.cid] = done
+				socket.engine.socket_send(socket, message)
+			else
+				socket.engine.socket_send(socket, message)
+				done(true)
+			end
 		end)
 	end
 end
@@ -45,6 +64,10 @@ function M.create(client)
 	assert(type(socket) == "table", "The created instance must be a table")
 	socket.client = client
 	socket.engine = client.engine
+	
+	-- callbacks
+	socket.cid = 0
+	socket.requests = {}
 
 	-- event handlers are registered here
 	socket.events = {}
@@ -168,7 +191,6 @@ def type_to_lua(t):
 	elif t == "map":
 		return "table"
 	else:
-		print("WARNING: Unknown type '%s' - Will use type 'table'" % t)
 		return "table"
 
 
@@ -194,7 +216,7 @@ def parse_proto_message(message):
 	return properties
 
 
-def message_to_lua(message_id, api):
+def message_to_lua(message_id, api, wait_for_callback):
 	message = get_proto_message(message_id, api)
 	if not message:
 		print("Unable to find message %s" % message_id)
@@ -219,7 +241,11 @@ def message_to_lua(message_id, api):
 	lua = lua + "	assert(socket)\n"
 	for prop in props:
 		lua = lua + "	assert(%s == nil or _G.type(%s) == '%s')\n" % (prop["name"], prop["name"], prop["type"])
+	if wait_for_callback:
+		lua = lua + "	socket.cid = socket.cid + 1\n"
 	lua = lua + "	local message = {\n"
+	if wait_for_callback:
+		lua = lua + "		cid = tostring(socket.cid),\n"
 	lua = lua + "		%s = {\n" % message_id
 	for prop in props:
 		lua = lua + "			%s = %s,\n" % (prop["name"], prop["name"])
@@ -260,10 +286,13 @@ def messages_to_lua(rtapi):
 	STATUS_MESSAGES = [ "StatusFollow", "StatusUnfollow", "StatusUpdate" ]
 	ALL_MESSAGES = CHANNEL_MESSAGES + MATCH_MESSAGES + MATCHMAKER_MESSAGES + PARTY_MESSAGES + STATUS_MESSAGES
 
+	NO_CALLBACK_MESSAGES = [ "MatchDataSend", "PartyDataSend" ]
+
 	ids = []
 	lua = ""
 	for message_id in ALL_MESSAGES:
-		lua = lua + message_to_lua(message_id, rtapi)
+		wait_for_callback = (message_id not in NO_CALLBACK_MESSAGES)
+		lua = lua + message_to_lua(message_id, rtapi, wait_for_callback)
 		ids.append(message_id)
 
 	return { "ids": ids, "lua": lua }

--- a/nakama/engine/test.lua
+++ b/nakama/engine/test.lua
@@ -67,10 +67,9 @@ function M.socket_connect(socket, callback)
 	callback(result)
 end
 
-function M.socket_send(socket, message, callback)
+function M.socket_send(socket, message)
 	table.insert(socket_send_queue, message)
-	local result = {}
-	callback(result)
+	callback({})
 end
 
 

--- a/nakama/engine/test.lua
+++ b/nakama/engine/test.lua
@@ -69,7 +69,6 @@ end
 
 function M.socket_send(socket, message)
 	table.insert(socket_send_queue, message)
-	callback({})
 end
 
 

--- a/nakama/socket.lua
+++ b/nakama/socket.lua
@@ -35,7 +35,7 @@ local function socket_send(socket, message, callback)
 			socket.engine.socket_send(socket, message)
 		else
 			socket.engine.socket_send(socket, message)
-			callback(true)
+			callback({})
 		end
 	else
 		return async(function(done)
@@ -44,7 +44,7 @@ local function socket_send(socket, message, callback)
 				socket.engine.socket_send(socket, message)
 			else
 				socket.engine.socket_send(socket, message)
-				done(true)
+				done({})
 			end
 		end)
 	end

--- a/nakama/socket.lua
+++ b/nakama/socket.lua
@@ -149,9 +149,7 @@ end
 function M.channel_leave(socket, channel_id, callback)
 	assert(socket)
 	assert(channel_id == nil or _G.type(channel_id) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		channel_leave = {
 			channel_id = channel_id,
 		}
@@ -296,9 +294,7 @@ end
 function M.match_leave(socket, match_id, callback)
 	assert(socket)
 	assert(match_id == nil or _G.type(match_id) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		match_leave = {
 			match_id = match_id,
 		}
@@ -345,9 +341,7 @@ end
 function M.matchmaker_remove(socket, ticket, callback)
 	assert(socket)
 	assert(ticket == nil or _G.type(ticket) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		matchmaker_remove = {
 			ticket = ticket,
 		}
@@ -382,9 +376,7 @@ end
 function M.party_join(socket, party_id, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		party_join = {
 			party_id = party_id,
 		}
@@ -399,9 +391,7 @@ end
 function M.party_leave(socket, party_id, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		party_leave = {
 			party_id = party_id,
 		}
@@ -418,9 +408,7 @@ function M.party_promote(socket, party_id, presence, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(presence == nil or _G.type(presence) == 'table')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		party_promote = {
 			party_id = party_id,
 			presence = presence,
@@ -438,9 +426,7 @@ function M.party_accept(socket, party_id, presence, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(presence == nil or _G.type(presence) == 'table')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		party_accept = {
 			party_id = party_id,
 			presence = presence,
@@ -458,9 +444,7 @@ function M.party_remove(socket, party_id, presence, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(presence == nil or _G.type(presence) == 'table')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		party_remove = {
 			party_id = party_id,
 			presence = presence,
@@ -476,9 +460,7 @@ end
 function M.party_close(socket, party_id, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		party_close = {
 			party_id = party_id,
 		}
@@ -547,9 +529,7 @@ function M.party_matchmaker_remove(socket, party_id, ticket, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(ticket == nil or _G.type(ticket) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		party_matchmaker_remove = {
 			party_id = party_id,
 			ticket = ticket,
@@ -606,9 +586,7 @@ end
 function M.status_unfollow(socket, user_ids, callback)
 	assert(socket)
 	assert(user_ids == nil or _G.type(user_ids) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		status_unfollow = {
 			user_ids = user_ids,
 		}
@@ -623,9 +601,7 @@ end
 function M.status_update(socket, status, callback)
 	assert(socket)
 	assert(status == nil or _G.type(status) == 'string')
-	socket.cid = socket.cid + 1
 	local message = {
-		cid = tostring(socket.cid),
 		status_update = {
 			status = status,
 		}

--- a/nakama/socket.lua
+++ b/nakama/socket.lua
@@ -9,6 +9,13 @@ local function on_socket_message(socket, message)
 	if message.match_data then
 		message.match_data.data = b64.decode(message.match_data.data)
 	end
+	if message.cid then
+		local callback = socket.requests[message.cid]
+		if callback then
+			callback(message)
+		end
+		socket.requests[message.cid] = nil
+	end
 	for event_id,_ in pairs(message) do
 		if socket.events[event_id] then
 			socket.events[event_id](message)
@@ -22,12 +29,23 @@ local function socket_send(socket, message, callback)
 	if message.match_data_send and message.match_data_send.data then
 		message.match_data_send.data = b64.encode(message.match_data_send.data)
 	end
-
 	if callback then
-		socket.engine.socket_send(socket, message, callback)
+		if message.cid then
+			socket.requests[message.cid] = callback
+			socket.engine.socket_send(socket, message)
+		else
+			socket.engine.socket_send(socket, message)
+			callback(true)
+		end
 	else
 		return async(function(done)
-			socket.engine.socket_send(socket, message, done)
+			if message.cid then
+				socket.requests[message.cid] = done
+				socket.engine.socket_send(socket, message)
+			else
+				socket.engine.socket_send(socket, message)
+				done(true)
+			end
 		end)
 	end
 end
@@ -39,6 +57,10 @@ function M.create(client)
 	assert(type(socket) == "table", "The created instance must be a table")
 	socket.client = client
 	socket.engine = client.engine
+	
+	-- callbacks
+	socket.cid = 0
+	socket.requests = {}
 
 	-- event handlers are registered here
 	socket.events = {}
@@ -107,7 +129,9 @@ function M.channel_join(socket, target, type, persistence, hidden, callback)
 	assert(type == nil or _G.type(type) == 'number')
 	assert(persistence == nil or _G.type(persistence) == 'boolean')
 	assert(hidden == nil or _G.type(hidden) == 'boolean')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		channel_join = {
 			target = target,
 			type = type,
@@ -125,7 +149,9 @@ end
 function M.channel_leave(socket, channel_id, callback)
 	assert(socket)
 	assert(channel_id == nil or _G.type(channel_id) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		channel_leave = {
 			channel_id = channel_id,
 		}
@@ -142,7 +168,9 @@ function M.channel_message_send(socket, channel_id, content, callback)
 	assert(socket)
 	assert(channel_id == nil or _G.type(channel_id) == 'string')
 	assert(content == nil or _G.type(content) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		channel_message_send = {
 			channel_id = channel_id,
 			content = content,
@@ -160,7 +188,9 @@ function M.channel_message_remove(socket, channel_id, message_id, callback)
 	assert(socket)
 	assert(channel_id == nil or _G.type(channel_id) == 'string')
 	assert(message_id == nil or _G.type(message_id) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		channel_message_remove = {
 			channel_id = channel_id,
 			message_id = message_id,
@@ -180,7 +210,9 @@ function M.channel_message_update(socket, channel_id, message_id, content, callb
 	assert(channel_id == nil or _G.type(channel_id) == 'string')
 	assert(message_id == nil or _G.type(message_id) == 'string')
 	assert(content == nil or _G.type(content) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		channel_message_update = {
 			channel_id = channel_id,
 			message_id = message_id,
@@ -224,7 +256,9 @@ end
 function M.match_create(socket, name, callback)
 	assert(socket)
 	assert(name == nil or _G.type(name) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		match_create = {
 			name = name,
 		}
@@ -243,7 +277,9 @@ function M.match_join(socket, match_id, token, metadata, callback)
 	assert(match_id == nil or _G.type(match_id) == 'string')
 	assert(token == nil or _G.type(token) == 'string')
 	assert(metadata == nil or _G.type(metadata) == 'table')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		match_join = {
 			match_id = match_id,
 			token = token,
@@ -260,7 +296,9 @@ end
 function M.match_leave(socket, match_id, callback)
 	assert(socket)
 	assert(match_id == nil or _G.type(match_id) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		match_leave = {
 			match_id = match_id,
 		}
@@ -285,7 +323,9 @@ function M.matchmaker_add(socket, min_count, max_count, query, string_properties
 	assert(string_properties == nil or _G.type(string_properties) == 'table')
 	assert(numeric_properties == nil or _G.type(numeric_properties) == 'table')
 	assert(count_multiple == nil or _G.type(count_multiple) == 'number')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		matchmaker_add = {
 			min_count = min_count,
 			max_count = max_count,
@@ -305,7 +345,9 @@ end
 function M.matchmaker_remove(socket, ticket, callback)
 	assert(socket)
 	assert(ticket == nil or _G.type(ticket) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		matchmaker_remove = {
 			ticket = ticket,
 		}
@@ -322,7 +364,9 @@ function M.party_create(socket, open, max_size, callback)
 	assert(socket)
 	assert(open == nil or _G.type(open) == 'boolean')
 	assert(max_size == nil or _G.type(max_size) == 'number')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_create = {
 			open = open,
 			max_size = max_size,
@@ -338,7 +382,9 @@ end
 function M.party_join(socket, party_id, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_join = {
 			party_id = party_id,
 		}
@@ -353,7 +399,9 @@ end
 function M.party_leave(socket, party_id, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_leave = {
 			party_id = party_id,
 		}
@@ -370,7 +418,9 @@ function M.party_promote(socket, party_id, presence, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(presence == nil or _G.type(presence) == 'table')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_promote = {
 			party_id = party_id,
 			presence = presence,
@@ -388,7 +438,9 @@ function M.party_accept(socket, party_id, presence, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(presence == nil or _G.type(presence) == 'table')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_accept = {
 			party_id = party_id,
 			presence = presence,
@@ -406,7 +458,9 @@ function M.party_remove(socket, party_id, presence, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(presence == nil or _G.type(presence) == 'table')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_remove = {
 			party_id = party_id,
 			presence = presence,
@@ -422,7 +476,9 @@ end
 function M.party_close(socket, party_id, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_close = {
 			party_id = party_id,
 		}
@@ -437,7 +493,9 @@ end
 function M.party_join_request_list(socket, party_id, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_join_request_list = {
 			party_id = party_id,
 		}
@@ -464,7 +522,9 @@ function M.party_matchmaker_add(socket, party_id, min_count, max_count, query, s
 	assert(string_properties == nil or _G.type(string_properties) == 'table')
 	assert(numeric_properties == nil or _G.type(numeric_properties) == 'table')
 	assert(count_multiple == nil or _G.type(count_multiple) == 'number')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_matchmaker_add = {
 			party_id = party_id,
 			min_count = min_count,
@@ -487,7 +547,9 @@ function M.party_matchmaker_remove(socket, party_id, ticket, callback)
 	assert(socket)
 	assert(party_id == nil or _G.type(party_id) == 'string')
 	assert(ticket == nil or _G.type(ticket) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		party_matchmaker_remove = {
 			party_id = party_id,
 			ticket = ticket,
@@ -526,7 +588,9 @@ function M.status_follow(socket, user_ids, usernames, callback)
 	assert(socket)
 	assert(user_ids == nil or _G.type(user_ids) == 'string')
 	assert(usernames == nil or _G.type(usernames) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		status_follow = {
 			user_ids = user_ids,
 			usernames = usernames,
@@ -542,7 +606,9 @@ end
 function M.status_unfollow(socket, user_ids, callback)
 	assert(socket)
 	assert(user_ids == nil or _G.type(user_ids) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		status_unfollow = {
 			user_ids = user_ids,
 		}
@@ -557,7 +623,9 @@ end
 function M.status_update(socket, status, callback)
 	assert(socket)
 	assert(status == nil or _G.type(status) == 'string')
+	socket.cid = socket.cid + 1
 	local message = {
+		cid = tostring(socket.cid),
 		status_update = {
 			status = status,
 		}
@@ -760,3 +828,4 @@ M.ERROR_RUNTIME_FUNCTION_NOT_FOUND = 6
 M.ERROR_RUNTIME_FUNCTION_EXCEPTION = 7
 
 return M
+


### PR DESCRIPTION
The socket code expected all messages to return a response from the server when in fact match and party data messages are "fire and forget". This change makes sure that match data and party data message complete immediately when the message has been sent. The message callback handling has also been improved and moved from the engine specific code to the generic socket code.

Fixes #77 