### PR TITLE
Fixed bug in exponential retry intervals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Run tests
       run: |
         lua -v
-        ./tsc -f test/test_socket.lua test/test_nakama.lua test/test_satori.lua test/test_session.lua
+        ./tsc -f test/test_socket.lua test/test_nakama.lua test/test_satori.lua test/test_session.lua test/test_retries.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Creating an exponentially increasing retry interval caused a Lua error
+
 ## [3.3.0] - 2024-06-14
 ### Fixed
 - Fixed issue with wrong argument name for `nakama.rpc_func`

--- a/nakama/util/retries.lua
+++ b/nakama/util/retries.lua
@@ -9,7 +9,7 @@ local M = {}
 function M.exponential(attempts, interval)
 	local delays = {}
 	for i=1,attempts do
-		delays[i] = (i > 1) and delays[i] * 2 or interval
+		delays[i] = (i > 1) and delays[i - 1] * 2 or interval
 	end
 	return delays
 end

--- a/test/test_retries.lua
+++ b/test/test_retries.lua
@@ -1,0 +1,52 @@
+local retries = require "nakama.util.retries"
+local log = require "nakama.util.log"
+log.print()
+
+context("Retries", function()
+
+	before(function() end)
+	after(function() end)
+
+	test("create exponentially increasing intervals", function()
+		local intervals = retries.exponential(5, 0.5)
+		assert(#intervals == 5)
+		assert(intervals[1] == 0.5)
+		assert(intervals[2] == 1.0)
+		assert(intervals[3] == 2.0)
+		assert(intervals[4] == 4.0)
+		assert(intervals[5] == 8.0)
+	end)
+
+	test("create incrementally increasing intervals", function()
+		local intervals = retries.incremental(5, 0.5)
+		assert(#intervals == 5)
+		assert(intervals[1] == 0.5)
+		assert(intervals[2] == 1.0)
+		assert(intervals[3] == 1.5)
+		assert(intervals[4] == 2.0)
+		assert(intervals[5] == 2.5)
+	end)
+
+	test("create fixed intervals", function()
+		local intervals = retries.fixed(5, 0.5)
+		assert(#intervals == 5)
+		assert(intervals[1] == 0.5)
+		assert(intervals[2] == 0.5)
+		assert(intervals[3] == 0.5)
+		assert(intervals[4] == 0.5)
+		assert(intervals[5] == 0.5)
+	end)
+
+	test("create no intervals", function()
+		local intervals = retries.none()
+		assert(#intervals == 0)
+		intervals = retries.exponential(0, 0)
+		assert(#intervals == 0)
+		intervals = retries.incremental(0, 0)
+		assert(#intervals == 0)
+		intervals = retries.fixed(0, 0)
+		assert(#intervals == 0)
+	end)
+end)
+
+


### PR DESCRIPTION
Fixed crash when creating an exponential retry interval. Also added tests for the retries.lua module.

```
./nakama/util/retries.lua:12: attempt to perform arithmetic on a nil value (field '?')
stack traceback:
	./nakama/util/retries.lua:12: in function 'nakama.util.retries.exponential'
	test/test_retries.lua:11: in function <test/test_retries.lua:10>
	[C]: in function 'xpcall'
	./telescope.lua:418: in local 'invoke_test'
	./telescope.lua:458: in function 'telescope.run'
	./tsc:274: in main chunk
	[C]: in ?
```